### PR TITLE
Fix: Ensure ufAlerts is initialized in ufForm _defaultError method

### DIFF
--- a/app/assets/userfrosting/js/uf-form.js
+++ b/app/assets/userfrosting/js/uf-form.js
@@ -227,8 +227,6 @@
         // Error messages
         if (!this.settings.msgTarget.data('ufAlerts')) {
             this.settings.msgTarget.ufAlerts();
-        } else {
-            this.settings.msgTarget.ufAlerts('clear');
         }
         
         if (this._debugAjax && jqXHR.responseText) {

--- a/app/assets/userfrosting/js/uf-form.js
+++ b/app/assets/userfrosting/js/uf-form.js
@@ -225,6 +225,12 @@
      */
     Plugin.prototype._defaultError = function (jqXHR, textStatus, errorThrown) {
         // Error messages
+        if (!this.settings.msgTarget.data('ufAlerts')) {
+            this.settings.msgTarget.ufAlerts();
+        } else {
+            this.settings.msgTarget.ufAlerts('clear');
+        }
+        
         if (this._debugAjax && jqXHR.responseText) {
             this.$element.trigger('submitError.ufForm', [jqXHR, textStatus, errorThrown]);
             this.settings.msgTarget.ufAlerts('push', 'danger', jqXHR.responseJSON.description).ufAlerts('render');


### PR DESCRIPTION
In uf-form.js: 
- Added a check to ensure `msgTarget` has `ufAlerts` initialized.

This fixes UF alerts not showing up in forms in my application. Other people had this issue too, judging from the support chat. 

My aim with this fix is to increase alert reliability in Userfrosting.